### PR TITLE
Remove `distutils` dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Rules-Requires-Root: no
 
 Package: setup-wizard-dist
 Architecture: all
-Depends: setup-dist, python3-yaml, python3-distutils,
+Depends: setup-dist, python3-yaml,
  helper-scripts, python3, x11-xserver-utils,
  ${misc:Depends}
 Recommends: icon-pack-dist


### PR DESCRIPTION
This pull request changes...

## Changes

`distutils` was removed in Python 3.12, per deprecation in PEP 632. It is not present in Debian Trixie and higher.

Removing `distutils` from Kicksecure dependencies fixes issues when distro-morphing Debian Trixie and higher to Kicksecure. It is also necessary for installing Kicksecure on ports-only architectures such as `ppc64`.

As best I can tell, `setup-wizard-dist` is not actually using `distutils` anywhere, so no code changes or new dependencies should be necessary. If I am mistaken on this, `python3-setuptools` is supposedly a drop-in replacement.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ ] I have tested it locally
    * I have tested that it fixes this package conflict on `ppc64`; I haven't been able to test beyond that because of another (independent) package conflict on ppc64 that I am now working on a PR for.
- [ ] I have reviewed and updated any documentation if relevant
    * No docs AFAICT.
- [ ] I am providing new code and test(s) for it
    * No new code, just removal.
